### PR TITLE
Add serialization support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bktree"
-version = "1.1.1"
+version = "2.0.1"
 authors = ["IGI-111 <igi-111@protonmail.com>"]
 edition = "2018"
 description = "BK-tree datastructure"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bktree"
-version = "1.0.1"
+version = "1.1.1"
 authors = ["IGI-111 <igi-111@protonmail.com>"]
 edition = "2018"
 description = "BK-tree datastructure"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,10 @@ license = "MIT"
 
 [dependencies]
 num = "0.4.0"
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[dev-dependencies]
+bincode = "1.3"
+
+[features]
+serde-support = ["serde"]

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -1,53 +1,67 @@
-pub fn hamming_distance<T: num::PrimInt>(a: &T, b: &T) -> isize {
-    (*a ^ *b).count_ones() as isize
+pub trait Distance<T: ?Sized> {
+    fn distance(&self, a: &T, b: &T) -> isize;
 }
 
-pub fn levenshtein_distance<S: AsRef<str>>(a: &S, b: &S) -> isize {
-    let a = a.as_ref();
-    let b = b.as_ref();
+#[derive(Debug)]
+pub struct HammingDistance;
 
-    if a == b {
-        return 0;
-    }
+#[derive(Debug)]
+pub struct LevenshteinDistance;
 
-    let a_len = a.chars().count();
-    let b_len = b.chars().count();
+impl<T: AsRef<str> + ?Sized> Distance<T> for LevenshteinDistance {
+    fn distance(&self, a: &T, b: &T) -> isize {
+        let a = a.as_ref();
+        let b = b.as_ref();
 
-    if a_len == 0 {
-        return b_len as isize;
-    }
+        if a == b {
+            return 0;
+        }
 
-    if b_len == 0 {
-        return a_len as isize;
-    }
+        let a_len = a.chars().count();
+        let b_len = b.chars().count();
 
-    let mut res = 0;
-    let mut cache: Vec<usize> = (1..).take(a_len).collect();
-    let mut a_dist;
-    let mut b_dist;
+        if a_len == 0 {
+            return b_len as isize;
+        }
 
-    for (ib, cb) in b.chars().enumerate() {
-        res = ib;
-        a_dist = ib;
-        for (ia, ca) in a.chars().enumerate() {
-            b_dist = if ca == cb { a_dist } else { a_dist + 1 };
-            a_dist = cache[ia];
+        if b_len == 0 {
+            return a_len as isize;
+        }
 
-            res = if a_dist > res {
-                if b_dist > res {
-                    res + 1
+        let mut res = 0;
+        let mut cache: Vec<usize> = (1..).take(a_len).collect();
+        let mut a_dist;
+        let mut b_dist;
+
+        for (ib, cb) in b.chars().enumerate() {
+            res = ib;
+            a_dist = ib;
+            for (ia, ca) in a.chars().enumerate() {
+                b_dist = if ca == cb { a_dist } else { a_dist + 1 };
+                a_dist = cache[ia];
+
+                res = if a_dist > res {
+                    if b_dist > res {
+                        res + 1
+                    } else {
+                        b_dist
+                    }
+                } else if b_dist > a_dist {
+                    a_dist + 1
                 } else {
                     b_dist
-                }
-            } else if b_dist > a_dist {
-                a_dist + 1
-            } else {
-                b_dist
-            };
+                };
 
-            cache[ia] = res;
+                cache[ia] = res;
+            }
         }
-    }
 
-    res as isize
+        res as isize
+    }
+}
+
+impl<T: num::PrimInt + ?Sized> Distance<T> for HammingDistance {
+    fn distance(&self, a: &T, b: &T) -> isize {
+        (*a ^ *b).count_ones() as isize
+    }
 }

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -2,9 +2,17 @@ pub trait Distance<T: ?Sized> {
     fn distance(&self, a: &T, b: &T) -> isize;
 }
 
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[derive(Debug)]
 pub struct HammingDistance;
 
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[derive(Debug)]
 pub struct LevenshteinDistance;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,44 +249,44 @@ mod tests {
 
         // Test exact search (zero tolerance)
         for word in &words {
-            let (wordList, distList): (Vec<&str>, Vec<isize>) =
+            let (word_list, dist_list): (Vec<&str>, Vec<isize>) =
                 bk.find(word, 0).into_iter().unzip();
-            assert_eq!(wordList, vec![*word]);
-            assert_eq!(distList, vec![0]);
+            assert_eq!(word_list, vec![*word]);
+            assert_eq!(dist_list, vec![0]);
         }
 
         // Test fuzzy search
-        let (wordList, distList): (Vec<&str>, Vec<isize>) = bk.find("ca", 3).into_iter().unzip();
-        assert_eq!(wordList, vec!["cake", "boo", "cape", "cart", "cook"]);
-        assert_eq!(distList, vec![2, 3, 2, 2, 3]);
+        let (word_list, dist_list): (Vec<&str>, Vec<isize>) = bk.find("ca", 3).into_iter().unzip();
+        assert_eq!(word_list, vec!["cake", "boo", "cape", "cart", "cook"]);
+        assert_eq!(dist_list, vec![2, 3, 2, 2, 3]);
 
         // Test for false positives
-        let (wordList, distList): (Vec<&str>, Vec<isize>) =
+        let (word_list, dist_list): (Vec<&str>, Vec<isize>) =
             bk.find("not here", 0).into_iter().unzip();
-        assert_eq!(wordList, vec![""; 0]);
-        assert_eq!(distList, vec![0; 0]);
+        assert_eq!(word_list, vec![""; 0]);
+        assert_eq!(dist_list, vec![0; 0]);
 
         let encoded_bk: Vec<u8> = bincode::serialize(&bk).unwrap();
         let decoded_bk: BkTree<&str> = bincode::deserialize(&encoded_bk[..]).unwrap();
 
         // Test exact search (zero tolerance)
         for word in &words {
-            let (wordList, distList): (Vec<&str>, Vec<isize>) =
+            let (word_list, dist_list): (Vec<&str>, Vec<isize>) =
                 decoded_bk.find(word, 0).into_iter().unzip();
-            assert_eq!(wordList, vec![*word]);
-            assert_eq!(distList, vec![0]);
+            assert_eq!(word_list, vec![*word]);
+            assert_eq!(dist_list, vec![0]);
         }
 
         // Test fuzzy search
-        let (wordList, distList): (Vec<&str>, Vec<isize>) =
+        let (word_list, dist_list): (Vec<&str>, Vec<isize>) =
             decoded_bk.find("ca", 3).into_iter().unzip();
-        assert_eq!(wordList, vec!["cake", "boo", "cape", "cart", "cook"]);
-        assert_eq!(distList, vec![2, 3, 2, 2, 3]);
+        assert_eq!(word_list, vec!["cake", "boo", "cape", "cart", "cook"]);
+        assert_eq!(dist_list, vec![2, 3, 2, 2, 3]);
 
         // Test for false positives
-        let (wordList, distList): (Vec<&str>, Vec<isize>) =
+        let (word_list, dist_list): (Vec<&str>, Vec<isize>) =
             decoded_bk.find("not here", 0).into_iter().unzip();
-        assert_eq!(wordList, vec![""; 0]);
-        assert_eq!(distList, vec![0; 0]);
+        assert_eq!(word_list, vec![""; 0]);
+        assert_eq!(dist_list, vec![0; 0]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,20 +238,6 @@ mod tests {
         assert_eq!(intoiter_res, [0, 15, 14, 5, 4]);
     }
 
-    fn assert_eq_sorted<'t, T: 't, I>(left: I, right: &[(u32, T)])
-    where
-        T: Ord + Debug,
-        I: Iterator<Item = (u32, &'t T)>,
-    {
-        let mut left_mut: Vec<_> = left.collect();
-        let mut right_mut: Vec<_> = right.iter().map(|&(dist, ref key)| (dist, key)).collect();
-
-        left_mut.sort();
-        right_mut.sort();
-
-        assert_eq!(left_mut, right_mut);
-    }
-
     #[cfg(feature = "serde-support")]
     #[test]
     fn test_serialization() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,10 +59,7 @@ where
 {
     /// Create a new BK-tree with a given distance function
     pub fn new(dist: D) -> Self {
-        Self {
-            root: None,
-            dist,
-        }
+        Self { root: None, dist }
     }
 
     /// Insert every element from a given iterator in the BK-tree

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ where
     D: Distance<T>,
 {
     /// Create a new BK-tree with a given distance function
-    pub fn new(dist: D) -> BkTree<T, D> {
+    pub fn new(dist: D) -> Self {
         Self {
             root: None,
             dist,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,6 @@ mod tests {
 
     use crate::distance::*;
     use crate::BkTree;
-    use std::fmt::Debug;
     #[test]
     fn levenshtein_distance_test() {
         let mut bk = BkTree::new(LevenshteinDistance);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,48 +259,48 @@ mod tests {
         let words = vec![
             "book", "books", "boo", "boon", "cook", "cake", "cape", "cart",
         ];
-        bk.insert_all(words);
+        bk.insert_all(words.clone());
 
         // Test exact search (zero tolerance)
-        for word in words {
+        for word in &words {
             let (wordList, distList): (Vec<&str>, Vec<isize>) =
                 bk.find(word, 0).into_iter().unzip();
-            assert_eq!(wordList, [word]);
-            assert_eq!(distList, [0]);
+            assert_eq!(wordList, vec![*word]);
+            assert_eq!(distList, vec![0]);
         }
 
         // Test fuzzy search
         let (wordList, distList): (Vec<&str>, Vec<isize>) = bk.find("ca", 3).into_iter().unzip();
-        assert_eq!(wordList, ["pickle", "rick"]);
-        assert_eq!(distList, [3, 153]);
+        assert_eq!(wordList, vec!["cake", "boo", "cape", "cart", "cook"]);
+        assert_eq!(distList, vec![2, 3, 2, 2, 3]);
 
         // Test for false positives
         let (wordList, distList): (Vec<&str>, Vec<isize>) =
             bk.find("not here", 0).into_iter().unzip();
-        assert_eq!(wordList, []);
-        assert_eq!(distList, []);
+        assert_eq!(wordList, vec![""; 0]);
+        assert_eq!(distList, vec![0; 0]);
 
         let encoded_bk: Vec<u8> = bincode::serialize(&bk).unwrap();
         let decoded_bk: BkTree<&str> = bincode::deserialize(&encoded_bk[..]).unwrap();
 
         // Test exact search (zero tolerance)
-        for word in words {
+        for word in &words {
             let (wordList, distList): (Vec<&str>, Vec<isize>) =
                 decoded_bk.find(word, 0).into_iter().unzip();
-            assert_eq!(wordList, [word]);
-            assert_eq!(distList, [0]);
+            assert_eq!(wordList, vec![*word]);
+            assert_eq!(distList, vec![0]);
         }
 
         // Test fuzzy search
         let (wordList, distList): (Vec<&str>, Vec<isize>) =
             decoded_bk.find("ca", 3).into_iter().unzip();
-        assert_eq!(wordList, ["pickle", "rick"]);
-        assert_eq!(distList, [3, 153]);
+        assert_eq!(wordList, vec!["cake", "boo", "cape", "cart", "cook"]);
+        assert_eq!(distList, vec![2, 3, 2, 2, 3]);
 
         // Test for false positives
         let (wordList, distList): (Vec<&str>, Vec<isize>) =
             decoded_bk.find("not here", 0).into_iter().unzip();
-        assert_eq!(wordList, []);
-        assert_eq!(distList, []);
+        assert_eq!(wordList, vec![""; 0]);
+        assert_eq!(distList, vec![0; 0]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ where
     pub fn new(dist: D) -> BkTree<T, D> {
         BkTree {
             root: None,
-            dist: dist,
+            dist,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ where
 {
     /// Create a new BK-tree with a given distance function
     pub fn new(dist: D) -> BkTree<T, D> {
-        BkTree {
+        Self {
             root: None,
             dist,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ impl<T, D> IntoIterator for BkTree<T, D> {
     fn into_iter(self) -> Self::IntoIter {
         let mut queue = Vec::new();
         if let Some(root) = self.root {
-            queue.push(*root);
+            queue.push(root);
         }
         IntoIter { queue }
     }


### PR DESCRIPTION
This PR creates the new trait `Distance` which has one method with the following signature:
```rust
pub trait Distance<T: ?Sized> {
    fn distance(&self, a: &T, b: &T) -> isize;
}
```
The functions `hamming_distance()` and `levenshtein_distance()` are refactored to `impl` the Distance trait for the new structs `HammingDistance` and `LevenshteinDistance`. These structs do not hold state, but can be passed in as type parameters to create `BkTree` objects with known size at compile time, e.g.
```rust
let mut bk = BkTree::new(HammingDistance);
// ...
let mut bk = BkTree::new(LevenshteinDistance);
```

The remainder of the refactor changes consist in refactoring `BkTree` to accept the second type parameter and fixing the unit tests accordingly.

Finally, this PR adds the `serde-support` feature to enable serializing and deserializing `BkTree` objects for those that would desire to do so. 

This constitutes a breaking change to the API of the `BkTree`. Adhering to [semver guidelines](https://semver.org), the major version of this crate has been incremented. 

Note that this PR leans heavily on the work done by @eugene-bulkin in the [rust-bk-tree](https://github.com/eugene-bulkin/rust-bk-tree) crate as well as the work on an [outstanding PR to support serialization](https://github.com/eugene-bulkin/rust-bk-tree/pull/12) in that crate by @stnbu